### PR TITLE
Fix forward entry setup

### DIFF
--- a/custom_components/unifi_bandwidth/__init__.py
+++ b/custom_components/unifi_bandwidth/__init__.py
@@ -12,7 +12,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     _LOGGER.info("UniFi Bandwidth Integration erfolgreich eingerichtet")
 
-    await hass.config_entries.async_forward_entry_setups(entry, "sensor")
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
 
     return True
 
@@ -20,7 +20,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Handle removal of an entry."""
     _LOGGER.info("UniFi Bandwidth Integration wird entfernt")
 
-    unload_ok = await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    unload_ok = await hass.config_entries.async_forward_entry_unload(entry, ["sensor"])
 
     if unload_ok:
         hass.data.pop(DOMAIN)

--- a/custom_components/unifi_bandwidth/__init__.py
+++ b/custom_components/unifi_bandwidth/__init__.py
@@ -12,7 +12,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     _LOGGER.info("UniFi Bandwidth Integration erfolgreich eingerichtet")
 
-    await hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    await hass.config_entries.async_forward_entry_setups(entry, "sensor")
 
     return True
 

--- a/custom_components/unifi_bandwidth/manifest.json
+++ b/custom_components/unifi_bandwidth/manifest.json
@@ -5,6 +5,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/TheFreeman/TF_hass_plugin_unifi_bandwidth",
+  "platforms": ["sensor"],
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/TheFreeman/TF_hass_plugin_unifi_bandwidth/issues",
   "requirements": [],


### PR DESCRIPTION
FIX: 
Corrected method name from async_forward_entry_setup to async_forward_entry_setups. 
See: https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/

Update async_forward_entry_setups and async_forward_entry_unload to use list format for platforms